### PR TITLE
[Modify] use uint*_t instead of uint*

### DIFF
--- a/include/felica_command.h
+++ b/include/felica_command.h
@@ -1,6 +1,6 @@
 /* $Id: felica_command.h,v 1.3 2008-01-15 12:24:26 hito Exp $ */
-#ifndef __FELICA_COMMAND_H
-#define __FELICA_COMMAND_H
+#ifndef LIBPAFE_FELICA_COMMAND_H
+#define LIBPAFE_FELICA_COMMAND_H
 
 /**
  * @brief REQC (リクエストコマンド C 型) を送信し、以降の通信で必要なデータを取得する。
@@ -11,7 +11,7 @@
  * @param timeslot タイムスロットの最大値を指定する。詳細は JIS X 6319-4 を参照のこと。
  * @return 成功した場合 `felica` 型のポインタを返す。返された `felica` 型のポインタは不要になったときに free(3) で開放する必要がある。 失敗すると NULL が返される。
  */
-felica *felica_polling(pasori *p, uint16 systemcode, uint8 RFU, uint8 timeslot);
+felica *felica_polling(pasori *p, uint16_t systemcode, uint8_t RFU, uint8_t timeslot);
 
 /**
  * @brief IDm (製造識別子) を取得する。
@@ -20,7 +20,7 @@ felica *felica_polling(pasori *p, uint16 systemcode, uint8 RFU, uint8 timeslot);
  * @param idm IDm を格納するためのポインタ。
  * @return 成功した場合 0 を返す。失敗すると 0 以外の数値が返される。
  */
-int felica_get_idm(felica *f, uint8 *idm);
+int felica_get_idm(felica *f, uint8_t *idm);
 
 /**
  * @brief PMm (製造パラメタ) を取得する。
@@ -29,7 +29,7 @@ int felica_get_idm(felica *f, uint8 *idm);
  * @param idm PMm を格納するためのポインタ。
  * @return 成功した場合 0 を返す。失敗すると 0 以外の数値が返される。
  */
-int felica_get_pmm(felica *f, uint8 *pmm);
+int felica_get_pmm(felica *f, uint8_t *pmm);
 
 /**
  * @brief Read コマンドを送信する。
@@ -42,7 +42,7 @@ int felica_get_pmm(felica *f, uint8 *pmm);
  *
  * @note RC-S330 では動作未確認。
  */
-int felica_read(felica *f, int *n, felica_block_info *info, uint8 *data);
+int felica_read(felica *f, int *n, felica_block_info *info, uint8_t *data);
 
 /**
  * @brief Read コマンドを送信する。ブロック数は 1 に固定。
@@ -54,7 +54,7 @@ int felica_read(felica *f, int *n, felica_block_info *info, uint8 *data);
  * @param data 応答データを格納するバッファへのポインタ。
  * @return 成功した場合 0 を返す。失敗すると 0 以外の数値が返される。
  */
-int felica_read_single(felica *f, int servicecode, int mode, uint8 block, uint8 *data);
+int felica_read_single(felica *f, int servicecode, int mode, uint8_t block, uint8_t *data);
 
 /**
  * @brief Request Service コマンドを送信する。
@@ -67,7 +67,7 @@ int felica_read_single(felica *f, int servicecode, int mode, uint8 block, uint8 
  *
  * @note RC-S330 では動作未確認。
  */
-int felica_request_service(felica *f, int *n, uint16 *list, uint16 *data);
+int felica_request_service(felica *f, int *n, uint16_t *list, uint16_t *data);
 
 /**
  * @brief Request Response コマンドを送信する。現在のモードを調べる。
@@ -78,7 +78,7 @@ int felica_request_service(felica *f, int *n, uint16 *list, uint16 *data);
  *
  * @note RC-S330 では動作未確認。
  */
-int felica_request_response(felica *f, uint8 *mode);
+int felica_request_response(felica *f, uint8_t *mode);
 
 /**
  * @brief 0xffffがサービスコードとして返却されるまで Search Service Code コマンドを送信する。
@@ -103,6 +103,6 @@ int felica_search_service(felica *f);
  * @param data 応答データを格納するバッファへのポインタ。
  * @return 成功した場合 0 を返す。失敗すると 0 以外の数値が返される。
  */
-int felica_request_system(felica *f, int *n, uint16 *data);
+int felica_request_system(felica *f, int *n, uint16_t *data);
 
 #endif

--- a/include/libpafe.h
+++ b/include/libpafe.h
@@ -1,16 +1,8 @@
 /* $Id: libpafe.h,v 1.8 2009-10-31 08:54:53 hito Exp $ */
-#ifndef __LIBPASORI_H
-#define __LIBPASORI_H
+#ifndef LIBPAFE_LIBPASORI_H
+#define LIBPAFE_LIBPASORI_H
 
-/* DEFINE types */
-
-#ifndef uint8
-typedef unsigned char uint8;
-#endif
-
-#ifndef uint16
-typedef unsigned short int uint16;
-#endif
+#include <stdint.h>
 
 /* DEFINE pasori */
 
@@ -26,7 +18,7 @@ typedef struct tag_pasori pasori;
 /*~DEFINE pasori */
 
 typedef struct _ferica_area {
-    uint16 code, attr, bin;
+    uint16_t code, attr, bin;
     struct _ferica_area *next;
 } felica_area;
 
@@ -34,26 +26,26 @@ typedef struct _ferica_area {
 
 struct tag_felica {
     pasori *p;
-    uint16 systemcode;
-    uint8 IDm[8];
-    uint8 PMm[8];
-    uint16 area_num;
+    uint16_t systemcode;
+    uint8_t IDm[8];
+    uint8_t PMm[8];
+    uint16_t area_num;
     felica_area area[256];
-    uint16 service_num;
+    uint16_t service_num;
     felica_area service[256];
     struct tag_felica *next;
 };
 typedef struct tag_felica felica;
 
 struct tag_felica_block {
-    uint8 data[8];
+    uint8_t data[8];
 };
 typedef struct tag_felica_block felica_block;
 
 typedef struct _felica_block_info {
-    uint16 service;
-    uint8 mode;
-    uint16 block;
+    uint16_t service;
+    uint8_t mode;
+    uint16_t block;
 } felica_block_info;
 
 /*~DEFINE felica */

--- a/include/pasori_command.h
+++ b/include/pasori_command.h
@@ -1,6 +1,6 @@
 /* $Id: pasori_command.h,v 1.3 2009-07-17 07:28:35 hito Exp $ */
-#ifndef __PASORI_COMMAND_H
-#define __PASORI_COMMAND_H
+#ifndef LIBPAFE_PASORI_COMMAND_H
+#define LIBPAFE_PASORI_COMMAND_H
 
 /**
  * @brief デバイスファイルをオープンする。
@@ -32,7 +32,7 @@ void pasori_close(pasori *p);
  * @param size 送出するデータへのポインタ。
  * @return 成功した場合 0 を返す。失敗すると 0 以外の数値が返される。
  */
-int pasori_send(pasori *p, uint8 *data, int *size);
+int pasori_send(pasori *p, uint8_t *data, int *size);
 
 /**
  * @brief PaSoRi からデータを受け取る。
@@ -42,7 +42,7 @@ int pasori_send(pasori *p, uint8 *data, int *size);
  * @param size バッファのサイズへのポインタ。
  * @return 成功した場合 0 を返す。失敗すると 0 以外の数値が返される。 size が参照している場所に格納したデータの長さが保存される。
  */
-int pasori_recv(pasori *p, uint8 *data, int *size);
+int pasori_recv(pasori *p, uint8_t *data, int *size);
 
 /**
  * @brief PaSoRi にコマンドを送出する。内部で pasori_send を呼び出している。
@@ -52,7 +52,7 @@ int pasori_recv(pasori *p, uint8 *data, int *size);
  * @param size 送出するデータのサイズへのポインタ。
  * @return 成功した場合 0 を返す。size が参照している場所に送出したデータの長さが保存される。失敗すると 0 以外の数値が返される。
  */
-int pasori_packet_write(pasori *p, uint8 *data, int *size);
+int pasori_packet_write(pasori *p, uint8_t *data, int *size);
 
 /**
  * @brief PaSoRi に送出したコマンドへの応答を取得する。内部で pasori_recv を呼び出している。
@@ -62,7 +62,7 @@ int pasori_packet_write(pasori *p, uint8 *data, int *size);
  * @param size バッファのサイズへのポインタ。
  * @return 成功した場合 0 を返す。size が参照している場所に取得したデータの長さが保存される。失敗すると 0 以外の数値が返される。
  */
-int pasori_packet_read(pasori *p, uint8 *data, int *size);
+int pasori_packet_read(pasori *p, uint8_t *data, int *size);
 
 /**
  * @brief FeliCa にデータを送信する。内部で pasori_packet_write を呼び出している。RC-S320 では PaSoRi2 コマンド 0x5C に対応する。
@@ -72,7 +72,7 @@ int pasori_packet_read(pasori *p, uint8 *data, int *size);
  * @param size バッファのサイズへのポインタ。
  * @return 成功した場合 0 を返す。size が参照している場所に送信したデータの長さが保存される。失敗すると 0 以外の数値が返される。
  */
-int pasori_write(pasori *p, uint8 *data, int *size);
+int pasori_write(pasori *p, uint8_t *data, int *size);
 
 /**
  * @brief FeliCa からの応答を受信する。内部で pasori_packet_read を呼び出している。
@@ -82,7 +82,7 @@ int pasori_write(pasori *p, uint8 *data, int *size);
  * @param size バッファのサイズへのポインタ。
  * @return 成功した場合 0 を返す。size が参照している場所に格納したデータの長さが保存される。失敗すると 0 以外の数値が返される。
  */
-int pasori_read(pasori *p, uint8 *data, int *size);
+int pasori_read(pasori *p, uint8_t *data, int *size);
 
 /**
  * @brief RC-S320 では Pasori にリセットコマンドを送出する。(PaSoRi2 コマンド 0x54) RC-S330 では RF Off などの処理を行う。
@@ -125,7 +125,7 @@ int pasori_type(pasori *p);
  *
  * @note RC-S320 のみ有効。
  */
-int pasori_test(pasori *p, int code, uint8 *data, int *size, uint8 *rdata, int *rsize);
+int pasori_test(pasori *p, int code, uint8_t *data, int *size, uint8_t *rdata, int *rsize);
 
 /**
  * @brief Pasori のエコーバックテストを行なう。(テストコード 0x00)
@@ -137,7 +137,7 @@ int pasori_test(pasori *p, int code, uint8 *data, int *size, uint8 *rdata, int *
  *
  * @note RC-S320 のみ有効。
  */
-int pasori_test_echo(pasori *p, uint8 *data, int *size);
+int pasori_test_echo(pasori *p, uint8_t *data, int *size);
 
 /**
  * @brief Pasori の EPROM テストを行なう。(テストコード 0x01)

--- a/src/felica_command.c
+++ b/src/felica_command.c
@@ -13,9 +13,9 @@
 /* read w/o encrypt */
 
 static int
-_felica_pasori_read(pasori *p, uint8 *data, int *size, int ofst) {
+_felica_pasori_read(pasori *p, uint8_t *data, int *size, int ofst) {
     int len, i;
-    uint8 buf[DATASIZE + 1];
+    uint8_t buf[DATASIZE + 1];
 
     len = *size;
 
@@ -39,7 +39,7 @@ _felica_pasori_read(pasori *p, uint8 *data, int *size, int ofst) {
 }
 
 static int
-felica_pasori_read(pasori *p, uint8 *data, int *size) {
+felica_pasori_read(pasori *p, uint8_t *data, int *size) {
     int ofst;
 
     switch (pasori_type(p)) {
@@ -68,9 +68,9 @@ search_service(int n, int *list, int val) {
 }
 
 static int
-pack_block_info(int n, felica_block_info *info, int *service_num, uint8 *services, uint8 *data) {
+pack_block_info(int n, felica_block_info *info, int *service_num, uint8_t *services, uint8_t *data) {
     int i, len, snum, s, slist[16] = {0};
-    uint8 *blklist;
+    uint8_t *blklist;
 
     snum = 0;
     len = 0;
@@ -108,10 +108,10 @@ pack_block_info(int n, felica_block_info *info, int *service_num, uint8 *service
     return len;
 }
 
-int felica_read(felica *f, int *n, felica_block_info *info, uint8 *data) {
-    uint8 cmd[DATASIZE + 1];
-    uint8 resp[DATASIZE + 1];
-    uint8 blklist[DATASIZE], services[DATASIZE];
+int felica_read(felica *f, int *n, felica_block_info *info, uint8_t *data) {
+    uint8_t cmd[DATASIZE + 1];
+    uint8_t resp[DATASIZE + 1];
+    uint8_t blklist[DATASIZE], services[DATASIZE];
     int i, size, blen, snum, num;
 
     if (f == NULL || n == NULL || info == NULL || data == NULL)
@@ -165,7 +165,7 @@ int felica_read(felica *f, int *n, felica_block_info *info, uint8 *data) {
     return 0;
 }
 
-int felica_read_single(felica *f, int servicecode, int mode, uint8 block, uint8 *data) {
+int felica_read_single(felica *f, int servicecode, int mode, uint8_t block, uint8_t *data) {
     int n;
     felica_block_info info;
 
@@ -178,10 +178,10 @@ int felica_read_single(felica *f, int servicecode, int mode, uint8 block, uint8 
 }
 
 felica *
-felica_polling(pasori *pp, uint16 systemcode, uint8 RFU, uint8 timeslot) {
+felica_polling(pasori *pp, uint16_t systemcode, uint8_t RFU, uint8_t timeslot) {
     felica *f;
-    uint8 cmd[5];
-    uint8 resp[DATASIZE + 1];
+    uint8_t cmd[5];
+    uint8_t resp[DATASIZE + 1];
     int l, n, ofst;
 
     Log("%s\n", __func__);
@@ -189,7 +189,7 @@ felica_polling(pasori *pp, uint16 systemcode, uint8 RFU, uint8 timeslot) {
     if (pp == NULL)
         return NULL;
 
-    cmd[0] = (uint8)FELICA_CMD_POLLING; /* command code */
+    cmd[0] = (uint8_t)FELICA_CMD_POLLING; /* command code */
     cmd[1] = H8(systemcode);
     cmd[2] = L8(systemcode);
     cmd[3] = RFU; /* zero */
@@ -232,7 +232,7 @@ felica_polling(pasori *pp, uint16 systemcode, uint8 RFU, uint8 timeslot) {
     return f;
 }
 
-int felica_get_idm(felica *f, uint8 *idm) {
+int felica_get_idm(felica *f, uint8_t *idm) {
     if (f == NULL || idm == NULL)
         return PASORI_ERR_PARM;
 
@@ -241,7 +241,7 @@ int felica_get_idm(felica *f, uint8 *idm) {
     return 0;
 }
 
-int felica_get_pmm(felica *f, uint8 *pmm) {
+int felica_get_pmm(felica *f, uint8_t *pmm) {
     if (f == NULL || pmm == NULL)
         return PASORI_ERR_PARM;
 
@@ -251,7 +251,7 @@ int felica_get_pmm(felica *f, uint8 *pmm) {
 }
 
 static void
-set_area_code(felica *f, uint16 data) {
+set_area_code(felica *f, uint16_t data) {
     int n;
 
     if (f == NULL)
@@ -271,9 +271,9 @@ set_area_code(felica *f, uint16 data) {
 }
 
 int felica_search_service(felica *f) {
-    uint8 cmd[DATASIZE + 1];
-    uint8 resp[DATASIZE + 1];
-    uint16 idx;
+    uint8_t cmd[DATASIZE + 1];
+    uint8_t resp[DATASIZE + 1];
+    uint16_t idx;
     int n, t;
 
     Log("%s\n", __func__);
@@ -311,9 +311,9 @@ int felica_search_service(felica *f) {
     return 0;
 }
 
-int felica_request_service(felica *f, int *n, uint16 *list, uint16 *data) {
-    uint8 cmd[DATASIZE + 1];
-    uint8 resp[DATASIZE + 1];
+int felica_request_service(felica *f, int *n, uint16_t *list, uint16_t *data) {
+    uint8_t cmd[DATASIZE + 1];
+    uint8_t resp[DATASIZE + 1];
     int i, len, r;
 
     Log("%s\n", __func__);
@@ -361,9 +361,9 @@ int felica_request_service(felica *f, int *n, uint16 *list, uint16 *data) {
     return 0;
 }
 
-int felica_request_response(felica *f, uint8 *mode) {
-    uint8 cmd[DATASIZE + 1];
-    uint8 resp[DATASIZE + 1];
+int felica_request_response(felica *f, uint8_t *mode) {
+    uint8_t cmd[DATASIZE + 1];
+    uint8_t resp[DATASIZE + 1];
     int len, r;
 
     Log("%s\n", __func__);
@@ -392,9 +392,9 @@ int felica_request_response(felica *f, uint8 *mode) {
     return 0;
 }
 
-int felica_request_system(felica *f, int *n, uint16 *data) {
-    uint8 cmd[DATASIZE + 1];
-    uint8 resp[DATASIZE + 1];
+int felica_request_system(felica *f, int *n, uint16_t *data) {
+    uint8_t cmd[DATASIZE + 1];
+    uint8_t resp[DATASIZE + 1];
     int i, len, r, num;
 
     Log("%s\n", __func__);

--- a/src/pasori_command.c
+++ b/src/pasori_command.c
@@ -1,35 +1,34 @@
 /* $Id: pasori_command.c,v 1.11 2009-10-09 07:43:13 hito Exp $ */
 /* pasori commands */
-#ifdef HAVE_CONFIG_H 
+#ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 
 #include "libpafe.h"
 
 #ifdef HAVE_LIBUSB_1
 #include <libusb.h>
 #define INTERFACE_NUMBER 0
-#else  /* HAVE_LIBUSB_1 */
+#else /* HAVE_LIBUSB_1 */
 #include <usb.h>
-#endif	/* HAVE_LIBUSB_1 */
+#endif /* HAVE_LIBUSB_1 */
 
-struct tag_pasori
-{
+struct tag_pasori {
 #ifdef HAVE_LIBUSB_1
-  libusb_device **devs;
-  libusb_context *ctx;
-  libusb_device_handle *dh;
-  struct libusb_device_descriptor desc;
+    libusb_device **devs;
+    libusb_context *ctx;
+    libusb_device_handle *dh;
+    struct libusb_device_descriptor desc;
 #else  /* HAVE_LIBUSB_1 */
-  struct usb_device *dev;
-  usb_dev_handle *dh;
-#endif	/* HAVE_LIBUSB_1 */
-  int b_ep_in, b_ep_out, i_ep_in;
-  int timeout;
-  enum PASORI_TYPE type;
+    struct usb_device *dev;
+    usb_dev_handle *dh;
+#endif /* HAVE_LIBUSB_1 */
+    int b_ep_in, b_ep_out, i_ep_in;
+    int timeout;
+    enum PASORI_TYPE type;
 };
 
 #define PASORIUSB_VENDOR 0x054c
@@ -40,299 +39,276 @@ struct tag_pasori
 #define TIMEOUT 1000
 
 /* FIXME: UNKNOWN CONSTANTS */
-static const uint8 S320_INIT0[] = { 0x62, 0x01, 0x82 };
+static const uint8_t S320_INIT0[] = {0x62, 0x01, 0x82};
 /* RET0                      {0x63,0x00,0x88}; */
 
-static const uint8 S320_INIT1[] = { 0x62, 0x02, 0x80, 0x81 };	/* INIT3 */
+static const uint8_t S320_INIT1[] = {0x62, 0x02, 0x80, 0x81}; /* INIT3 */
 /* RET1                      {0x63,0x00,0xcc,0x88}; */
 
-static const uint8 S320_INIT2[] = { 0x62, 0x22, 0x80, 0xcc, 0x81, 0x88 };
+static const uint8_t S320_INIT2[] = {0x62, 0x22, 0x80, 0xcc, 0x81, 0x88};
 /* RET2                      {0x63,0x00}; */
 
-static const uint8 S320_INIT3[] = { 0x62, 0x02, 0x80, 0x81 };	/* INIT1 */
+static const uint8_t S320_INIT3[] = {0x62, 0x02, 0x80, 0x81}; /* INIT1 */
 /* RET3                      {0x63,0x00,0xcc,0x88}; */
 
-static const uint8 S320_INIT4[] = { 0x62, 0x02, 0x82, 0x87 };
+static const uint8_t S320_INIT4[] = {0x62, 0x02, 0x82, 0x87};
 /* RET4                      {0x63,0x00,0x88,0x01}; */
 
-static const uint8 S320_INIT5[] = { 0x62, 0x21, 0x25, 0x58 };
+static const uint8_t S320_INIT5[] = {0x62, 0x21, 0x25, 0x58};
 /* RET5                      {0x63,0x00} */
 
-static const uint8 S320_READ0[] = { 0x58 };
+static const uint8_t S320_READ0[] = {0x58};
 /*RRET0                      {0x59,0x28,0x01} */
 
-static const uint8 S320_READ1[] = { 0x54 };
-static const uint8 S320_READ2[] = { 0x5a, 0x80 };
+static const uint8_t S320_READ1[] = {0x54};
+static const uint8_t S320_READ2[] = {0x5a, 0x80};
 
-static const uint8 S310_INIT[] = { 0x54 };
+static const uint8_t S310_INIT[] = {0x54};
 
-static const uint8 S330_RF_ANTENNA_ON[] = { 0xD4, 0x32, 0x01, 0x01 };
-static const uint8 S330_RF_ANTENNA_OFF[] = { 0xD4, 0x32, 0x01, 0x00 };
-static const uint8 S330_GET_VERSION[] = { 0xD4, 0x02 };
-static const uint8 S330_DESELECT[] = { 0xD4, 0x44, 0x01 };
-
+static const uint8_t S330_RF_ANTENNA_ON[] = {0xD4, 0x32, 0x01, 0x01};
+static const uint8_t S330_RF_ANTENNA_OFF[] = {0xD4, 0x32, 0x01, 0x00};
+static const uint8_t S330_GET_VERSION[] = {0xD4, 0x02};
+static const uint8_t S330_DESELECT[] = {0xD4, 0x44, 0x01};
 
 #define DATASIZE 255
 
 /* internal */
 
 static int
-checksum(uint8 *data, int size)
-{
-  int i, sum = 0;
+checksum(uint8_t *data, int size) {
+    int i, sum = 0;
 
-  if (data == NULL)
-    return 0;
+    if (data == NULL)
+        return 0;
 
-  for (i = 0; i != size; i++) {
-    sum += data[i];
-  }
-  sum &= 0xff;
-  sum = 0x100 - sum;
+    for (i = 0; i != size; i++) {
+        sum += data[i];
+    }
+    sum &= 0xff;
+    sum = 0x100 - sum;
 
-  return sum & 0xff;
+    return sum & 0xff;
 }
 
 static int
-pasori_init_test(pasori *p, const uint8 *testptrn, int size)
-{
-  uint8 recv[DATASIZE + 1];
-  int n, r;
+pasori_init_test(pasori *p, const uint8_t *testptrn, int size) {
+    uint8_t recv[DATASIZE + 1];
+    int n, r;
 
-  if (p == NULL || testptrn == NULL || size < 1)
-    return PASORI_ERR_PARM;
+    if (p == NULL || testptrn == NULL || size < 1)
+        return PASORI_ERR_PARM;
 
-  n = size;
-  r = pasori_packet_write(p, (uint8 *) testptrn, &n);
-  if (r)
+    n = size;
+    r = pasori_packet_write(p, (uint8_t *)testptrn, &n);
+    if (r)
+        return r;
+
+    n = DATASIZE;
+    r = pasori_recv(p, recv, &n);
+
     return r;
-
-  n = DATASIZE;
-  r = pasori_recv(p, recv, &n);
-
-  return r;
 }
 
 /* exports */
 
-int 
-pasori_test(pasori *p, int code, uint8 *data, int *size, uint8 *rdata, int *rsize)
-{
-  uint8 recv[DATASIZE + 1];
-  int n, r;
+int pasori_test(pasori *p, int code, uint8_t *data, int *size, uint8_t *rdata, int *rsize) {
+    uint8_t recv[DATASIZE + 1];
+    int n, r;
 
+    if (p == NULL || size == NULL)
+        return PASORI_ERR_PARM;
 
-  if (p == NULL || size == NULL)
-    return PASORI_ERR_PARM;
+    if (code == 0x00 && (size == NULL || rdata == NULL || rsize == NULL))
+        return PASORI_ERR_PARM;
 
-  if (code == 0x00 && (size ==NULL ||rdata == NULL || rsize == NULL))
-    return PASORI_ERR_PARM;
+    switch (p->type) {
+        case PASORI_TYPE_S310:
+        case PASORI_TYPE_S320:
+            break;
+        default:
+            return PASORI_ERR_TYPE;
+    }
 
-  switch (p->type) {
-  case PASORI_TYPE_S310:
-  case PASORI_TYPE_S320:
-    break;
-  default:
-    return PASORI_ERR_TYPE;
-  }
+    n = *size;
 
-  n = *size;
+    if (n > DATASIZE - 3)
+        return PASORI_ERR_PARM;
 
-  if (n > DATASIZE - 3)
-    return PASORI_ERR_PARM;
+    recv[0] = 0x52;
+    recv[1] = code;
+    recv[2] = *size;
+    if (n > 0) {
+        memcpy(recv + 3, data, n);
+    }
+    n += 3;
 
-  recv[0] = 0x52;
-  recv[1] = code;
-  recv[2] = *size;
-  if (n > 0) {
-    memcpy(recv + 3, data, n);
-  }
-  n += 3;
+    r = pasori_packet_write(p, recv, &n);
+    if (r)
+        return r;
 
-  r = pasori_packet_write(p, recv, &n);
-  if (r)
-    return r;
+    n = DATASIZE;
+    r = pasori_packet_read(p, recv, &n);
+    if (r)
+        return r;
 
-  n = DATASIZE;
-  r = pasori_packet_read(p, recv, &n);
-  if (r)
-    return r;
+    if (recv[0] != 0x53)
+        return PASORI_ERR_FORMAT;
 
-  if (recv[0] != 0x53)
-    return PASORI_ERR_FORMAT;
+    n = recv[1];
+    if (code != 0x00 && n != 1) {
+        return n;
+    }
 
-  n = recv[1];
-  if (code != 0x00 && n != 1) {
-    return n;
-  }
+    if (code != 0x00)
+        return 0;
 
-  if (code != 0x00)
+    if (n > *rsize)
+        n = *rsize;
+
+    recv[2 + n] = '\0';
+    memcpy(rdata, &recv[2], n);
+    *rsize = n;
     return 0;
-
-  if (n > *rsize)
-    n = *rsize;
-
-  recv[2 + n] = '\0';
-  memcpy(rdata, &recv[2], n);
-  *rsize = n;
-  return 0;
 }
 
-int 
-pasori_test_echo(pasori *p, uint8 *data, int *size)
-{
-  int n = *size, l = DATASIZE, r;
-  uint8 rdata[DATASIZE + 1];
+int pasori_test_echo(pasori *p, uint8_t *data, int *size) {
+    int n = *size, l = DATASIZE, r;
+    uint8_t rdata[DATASIZE + 1];
 
-  r = pasori_test(p, 0x00, data, &n, rdata, &l);
-  if (r)
-    return r;
+    r = pasori_test(p, 0x00, data, &n, rdata, &l);
+    if (r)
+        return r;
 
-  if (n != l)
-    return PASORI_ERR_DATA;
+    if (n != l)
+        return PASORI_ERR_DATA;
 
-  if (memcmp(data, rdata, n))
-    return PASORI_ERR_DATA;
+    if (memcmp(data, rdata, n))
+        return PASORI_ERR_DATA;
 
-  return 0;
-}
-
-int 
-pasori_test_eprom(pasori *p)
-{
-  uint8 recv[DATASIZE + 1];
-  int n = 0, rn = DATASIZE;
-  
-  return pasori_test(p, 0x01, NULL, &n, recv, &rn);
-}
-
-int 
-pasori_test_ram(pasori *p)
-{
-  int n = 0;
-  
-  return pasori_test(p, 0x02, NULL, &n, NULL, NULL);
-}
-
-int 
-pasori_test_cpu(pasori *p)
-{
-  int n = 0;
-  
-  return pasori_test(p, 0x03, NULL, &n, NULL, NULL);
-}
-
-int 
-pasori_test_polling(pasori *p)
-{
-  int n = 0;
-  
-  return pasori_test(p, 0x10, NULL, &n, NULL, NULL);
-}
-
-
-
-void 
-pasori_set_timeout(pasori *p, int timeout)
-{
-  if (p == NULL || timeout < 0)
-    return;
-
-  p->timeout = timeout;
-}
-
-int
-pasori_packet_write(pasori *p, uint8 *data, int *size)
-{				/* RAW Packet SEND */
-  uint8 cmd[DATASIZE + 1];
-  uint8 sum;
-  int i, n;
-
-  if (p == NULL || data == NULL || size == NULL)
-    return PASORI_ERR_PARM;
-
-  n = *size;
-
-  if (n < 1) {
-    *size = 0;
     return 0;
-  }
-
-  if (n > DATASIZE - 7)
-    n = DATASIZE - 7;
-
-  sum = checksum(data, n);
-
-  cmd[0] = 0;
-  cmd[1] = 0;;
-  cmd[2] = 0xff;
-  cmd[3] = n;
-  cmd[4] = 0x100 - n;
-  memcpy(cmd + 5, data, n);
-  cmd[5 + n] = sum;
-  cmd[6 + n] = 0;
-  n += 7;
-
-  i = pasori_send(p, cmd, &n);
-
-  *size = n - 7;
-
-  return i;
-  /* FIXME:handle error */
 }
 
-int
-pasori_packet_read(pasori * p, uint8 * data, int *size)
-{
-  uint8 recv[DATASIZE + 1];
-  unsigned int s;
-  int i, n, sum;
+int pasori_test_eprom(pasori *p) {
+    uint8_t recv[DATASIZE + 1];
+    int n = 0, rn = DATASIZE;
 
-  if (p == NULL || data == NULL || size == NULL)
-    return PASORI_ERR_PARM;
+    return pasori_test(p, 0x01, NULL, &n, recv, &rn);
+}
 
-  if (*size < 1) {
-    *size = 0;
+int pasori_test_ram(pasori *p) {
+    int n = 0;
+
+    return pasori_test(p, 0x02, NULL, &n, NULL, NULL);
+}
+
+int pasori_test_cpu(pasori *p) {
+    int n = 0;
+
+    return pasori_test(p, 0x03, NULL, &n, NULL, NULL);
+}
+
+int pasori_test_polling(pasori *p) {
+    int n = 0;
+
+    return pasori_test(p, 0x10, NULL, &n, NULL, NULL);
+}
+
+void pasori_set_timeout(pasori *p, int timeout) {
+    if (p == NULL || timeout < 0)
+        return;
+
+    p->timeout = timeout;
+}
+
+int pasori_packet_write(pasori *p, uint8_t *data, int *size) { /* RAW Packet SEND */
+    uint8_t cmd[DATASIZE + 1];
+    uint8_t sum;
+    int i, n;
+
+    if (p == NULL || data == NULL || size == NULL)
+        return PASORI_ERR_PARM;
+
+    n = *size;
+
+    if (n < 1) {
+        *size = 0;
+        return 0;
+    }
+
+    if (n > DATASIZE - 7)
+        n = DATASIZE - 7;
+
+    sum = checksum(data, n);
+
+    cmd[0] = 0;
+    cmd[1] = 0;
+    ;
+    cmd[2] = 0xff;
+    cmd[3] = n;
+    cmd[4] = 0x100 - n;
+    memcpy(cmd + 5, data, n);
+    cmd[5 + n] = sum;
+    cmd[6 + n] = 0;
+    n += 7;
+
+    i = pasori_send(p, cmd, &n);
+
+    *size = n - 7;
+
+    return i;
+    /* FIXME:handle error */
+}
+
+int pasori_packet_read(pasori *p, uint8_t *data, int *size) {
+    uint8_t recv[DATASIZE + 1];
+    unsigned int s;
+    int i, n, sum;
+
+    if (p == NULL || data == NULL || size == NULL)
+        return PASORI_ERR_PARM;
+
+    if (*size < 1) {
+        *size = 0;
+        return 0;
+    }
+
+    n = DATASIZE;
+    i = pasori_recv(p, recv, &n);
+
+    if (i)
+        return i; /* FIXME: handle timeout */
+
+    if (recv[0] != 0 || recv[1] != 0 || recv[2] != 0xff)
+        return PASORI_ERR_COM;
+
+    if (recv[5] == 0x7f)
+        return PASORI_ERR_FORMAT;
+
+    s = recv[3];
+    if (recv[4] != 0x100 - s)
+        return PASORI_ERR_CHKSUM;
+
+    sum = checksum(recv + 5, s);
+    if (recv[s + 5] != sum)
+        return PASORI_ERR_CHKSUM;
+
+    if (recv[s + 6] != 0)
+        return PASORI_ERR_COM;
+
+    if (s > n)
+        s = n;
+
+    memcpy(data, &recv[5], s);
+    *size = s;
+
     return 0;
-  }
-
-  n = DATASIZE;
-  i = pasori_recv(p, recv, &n);
-
-  if (i)
-    return i;			/* FIXME: handle timeout */
-
-  if (recv[0] != 0 || recv[1] != 0 || recv[2] != 0xff)
-    return PASORI_ERR_COM;
-
-  if (recv[5] == 0x7f)
-    return PASORI_ERR_FORMAT;
-
-  s = recv[3];
-  if (recv[4] != 0x100 - s)
-    return PASORI_ERR_CHKSUM;
-
-  sum = checksum(recv + 5, s);
-  if (recv[s + 5] != sum)
-    return PASORI_ERR_CHKSUM;
-
-  if (recv[s + 6] != 0)
-    return PASORI_ERR_COM;
-
-  if (s > n)
-    s = n;
-
-  memcpy(data, &recv[5], s);
-  *size = s;
-
-  return 0;
 }
 
 /*
- * 3th byte is the max number of target to sence.  
+ * 3th byte is the max number of target to sence.
  * It seems valid values are 0x01 or 0x02 for devices this driver suport, and
- * it can sences two targets at Mifare cards, but not at Felica cards.  
- * 
+ * it can sences two targets at Mifare cards, but not at Felica cards.
+ *
  * 4th byte may mean protocol(tag types).
  *   0x00 = mifare,iso14443A(106kbps*)
  *   0x01 = Felica(212kbps)
@@ -340,693 +316,666 @@ pasori_packet_read(pasori * p, uint8 * data, int *size)
  *   0x03 = iso14443B(106kbps*)
  *   0x04 = Nfc Forum Type1(106kbps*)
  *   *=default bit rate(To change this, use pn53x 'D44E' command.)
- * 
+ *
  * At least on default setting, it seems my pn531 dose not accept '0x03''0x04'.
- * RC-S330 accepts '0x03''0x04', but in the '0x03' case payload length is up to 
+ * RC-S330 accepts '0x03''0x04', but in the '0x03' case payload length is up to
  * 2 byte, in the '0x04' case payload length is zero , and in both case
  * 3th byte must be '0x01'.
- * 
+ *
  * */
-int 
-pasori_list_passive_target(pasori *pp, unsigned char *payload, int *size)
-{
-  int r, n;
-  unsigned char cmd[DATASIZE + 1];
+int pasori_list_passive_target(pasori *pp, unsigned char *payload, int *size) {
+    int r, n;
+    unsigned char cmd[DATASIZE + 1];
 
-  if(pp == NULL || payload == NULL || size == NULL || *size < 0) 
-    return PASORI_ERR_FORMAT;
+    if (pp == NULL || payload == NULL || size == NULL || *size < 0)
+        return PASORI_ERR_FORMAT;
 
-  if (pp->type != PASORI_TYPE_S330)
-    return PASORI_ERR_TYPE;
+    if (pp->type != PASORI_TYPE_S330)
+        return PASORI_ERR_TYPE;
 
-  cmd[0] = 0xd4;
-  cmd[1] = 0x4a;
-  cmd[2] = 1;
-  cmd[3] = 0x01;
-
-  n = *size;
-  memcpy(cmd + 4, payload, n);
-  n += 4;
-  r = pasori_packet_write(pp, cmd, &n);
-  *size = n - 4;
-
-  return r;			/* FIXME:handle error */
-}
-
-int
-pasori_write(pasori *p, uint8 *data, int *size)
-{
-  uint8 cmd[DATASIZE];
-  int r, n, head_len;
-
-  n = *size;
-
-  if (n > DATASIZE - 2)
-    return PASORI_ERR_PARM;
-
-  switch (p->type) {
-  case PASORI_TYPE_S310:
-  case PASORI_TYPE_S320:
-    cmd[0] = 0x5c;
-    cmd[1] = *size + 1;
-    head_len = 2;
-    break;
-  case PASORI_TYPE_S330:
     cmd[0] = 0xd4;
-    cmd[1] = 0x42;
-    cmd[2] = *size + 1;
-    head_len = 3;
-    break;
-  default:
-    return PASORI_ERR_TYPE;
-  }
+    cmd[1] = 0x4a;
+    cmd[2] = 1;
+    cmd[3] = 0x01;
 
-  memcpy(cmd + head_len, data, n);
-  n += head_len;
-  r = pasori_packet_write(p, cmd, &n);
-  *size = n - head_len;
+    n = *size;
+    memcpy(cmd + 4, payload, n);
+    n += 4;
+    r = pasori_packet_write(pp, cmd, &n);
+    *size = n - 4;
 
-  return r;			/* FIXME:handle error */
+    return r; /* FIXME:handle error */
 }
 
-int 
-pasori_read(pasori *p, uint8 *data, int *size)
-{
-  uint8 recv[DATASIZE + 1];
-  int s;
-  int n, r;
+int pasori_write(pasori *p, uint8_t *data, int *size) {
+    uint8_t cmd[DATASIZE];
+    int r, n, head_len;
 
-  if (p == NULL || data == NULL || size == NULL)
-    return PASORI_ERR_PARM;
+    n = *size;
 
-  if (*size < 1) {
-    *size = 0;
+    if (n > DATASIZE - 2)
+        return PASORI_ERR_PARM;
+
+    switch (p->type) {
+        case PASORI_TYPE_S310:
+        case PASORI_TYPE_S320:
+            cmd[0] = 0x5c;
+            cmd[1] = *size + 1;
+            head_len = 2;
+            break;
+        case PASORI_TYPE_S330:
+            cmd[0] = 0xd4;
+            cmd[1] = 0x42;
+            cmd[2] = *size + 1;
+            head_len = 3;
+            break;
+        default:
+            return PASORI_ERR_TYPE;
+    }
+
+    memcpy(cmd + head_len, data, n);
+    n += head_len;
+    r = pasori_packet_write(p, cmd, &n);
+    *size = n - head_len;
+
+    return r; /* FIXME:handle error */
+}
+
+int pasori_read(pasori *p, uint8_t *data, int *size) {
+    uint8_t recv[DATASIZE + 1];
+    int s;
+    int n, r;
+
+    if (p == NULL || data == NULL || size == NULL)
+        return PASORI_ERR_PARM;
+
+    if (*size < 1) {
+        *size = 0;
+        return 0;
+    }
+
+    n = DATASIZE;
+    r = pasori_packet_read(p, recv, &n);
+    if (r)
+        return r;
+
+    switch (p->type) {
+        case PASORI_TYPE_S310:
+        case PASORI_TYPE_S320:
+            if (recv[0] != 0x5d)
+                return PASORI_ERR_FORMAT;
+            s = recv[1];
+            break;
+        case PASORI_TYPE_S330:
+            if (recv[0] != 0xd5)
+                return PASORI_ERR_FORMAT;
+            s = n;
+            break;
+        default:
+            return PASORI_ERR_TYPE;
+    }
+
+    if (s > *size)
+        s = *size;
+
+    memcpy(data, recv + 2, s);
+    *size = s;
+
     return 0;
-  }
-
-  n = DATASIZE;
-  r = pasori_packet_read(p, recv, &n);
-  if (r)
-    return r;
-
-  switch (p->type) {
-  case PASORI_TYPE_S310:
-  case PASORI_TYPE_S320:
-    if (recv[0] != 0x5d)
-      return PASORI_ERR_FORMAT;
-    s = recv[1];
-    break;
-  case PASORI_TYPE_S330:
-    if (recv[0] != 0xd5)
-      return PASORI_ERR_FORMAT;
-    s = n;
-    break;
-  default:
-    return PASORI_ERR_TYPE;
-  }
-
-  if (s > *size)
-    s = *size;
-
-  memcpy(data, recv + 2, s);
-  *size = s;
-
-  return 0;
 }
 
-int
-pasori_init(pasori * p)
-{
-  if (p == NULL)
-    return PASORI_ERR_PARM;
+int pasori_init(pasori *p) {
+    if (p == NULL)
+        return PASORI_ERR_PARM;
 
-  switch (p->type) {
-  case PASORI_TYPE_S310:
-    pasori_init_test(p, S310_INIT, sizeof(S310_INIT));
-    break;
-  case PASORI_TYPE_S320:
-    pasori_init_test(p, S320_INIT0, sizeof(S320_INIT0));
-    pasori_init_test(p, S320_INIT1, sizeof(S320_INIT1));
-    pasori_init_test(p, S320_INIT2, sizeof(S320_INIT2));
-    pasori_init_test(p, S320_INIT3, sizeof(S320_INIT3));
-    pasori_init_test(p, S320_INIT4, sizeof(S320_INIT4));
-    pasori_init_test(p, S320_INIT5, sizeof(S320_INIT5));
+    switch (p->type) {
+        case PASORI_TYPE_S310:
+            pasori_init_test(p, S310_INIT, sizeof(S310_INIT));
+            break;
+        case PASORI_TYPE_S320:
+            pasori_init_test(p, S320_INIT0, sizeof(S320_INIT0));
+            pasori_init_test(p, S320_INIT1, sizeof(S320_INIT1));
+            pasori_init_test(p, S320_INIT2, sizeof(S320_INIT2));
+            pasori_init_test(p, S320_INIT3, sizeof(S320_INIT3));
+            pasori_init_test(p, S320_INIT4, sizeof(S320_INIT4));
+            pasori_init_test(p, S320_INIT5, sizeof(S320_INIT5));
 
-    pasori_init_test(p, S320_READ2, sizeof(S320_READ2));
-    break;
-  case PASORI_TYPE_S330:
-    pasori_init_test(p, S330_RF_ANTENNA_ON, sizeof(S330_RF_ANTENNA_ON));
-    break;
-  default:
-    return PASORI_ERR_TYPE;
-  }
-  return 0;
+            pasori_init_test(p, S320_READ2, sizeof(S320_READ2));
+            break;
+        case PASORI_TYPE_S330:
+            pasori_init_test(p, S330_RF_ANTENNA_ON, sizeof(S330_RF_ANTENNA_ON));
+            break;
+        default:
+            return PASORI_ERR_TYPE;
+    }
+    return 0;
 }
 
-int
-pasori_reset(pasori * p)
-{
-  if (p == NULL)
-    return PASORI_ERR_PARM;
+int pasori_reset(pasori *p) {
+    if (p == NULL)
+        return PASORI_ERR_PARM;
 
-  switch (p->type) {
-  case PASORI_TYPE_S310:
-    pasori_init_test(p, S310_INIT, sizeof(S310_INIT));
-    break;
-  case PASORI_TYPE_S320:
-    pasori_init_test(p, S320_READ1, sizeof(S320_READ1));
-    break;
-  case PASORI_TYPE_S330:
-    pasori_init_test(p, S330_DESELECT, sizeof(S330_DESELECT));
-    pasori_init_test(p, S330_RF_ANTENNA_OFF, sizeof(S330_RF_ANTENNA_ON));
-    break;
-  default:
-    return PASORI_ERR_TYPE;
-  }
+    switch (p->type) {
+        case PASORI_TYPE_S310:
+            pasori_init_test(p, S310_INIT, sizeof(S310_INIT));
+            break;
+        case PASORI_TYPE_S320:
+            pasori_init_test(p, S320_READ1, sizeof(S320_READ1));
+            break;
+        case PASORI_TYPE_S330:
+            pasori_init_test(p, S330_DESELECT, sizeof(S330_DESELECT));
+            pasori_init_test(p, S330_RF_ANTENNA_OFF, sizeof(S330_RF_ANTENNA_ON));
+            break;
+        default:
+            return PASORI_ERR_TYPE;
+    }
 
-  return 0;
+    return 0;
 }
 
 static int
-bcd2int(uint8 bcd)
-{
-  return ((bcd >> 4) & 0x0f) * 10 + (bcd & 0x0f);
+bcd2int(uint8_t bcd) {
+    return ((bcd >> 4) & 0x0f) * 10 + (bcd & 0x0f);
 }
 
-int
-pasori_version(pasori *p, int *v1, int *v2)
-{
-  uint8 recv[DATASIZE + 1];
-  int n, r;
+int pasori_version(pasori *p, int *v1, int *v2) {
+    uint8_t recv[DATASIZE + 1];
+    int n, r;
 
-  if (p == NULL || v1 == NULL || v2 == NULL)
-    return PASORI_ERR_PARM;
+    if (p == NULL || v1 == NULL || v2 == NULL)
+        return PASORI_ERR_PARM;
 
-  switch (p->type) {
-  case PASORI_TYPE_S310:
-  case PASORI_TYPE_S320:
-    recv[0] = 0x58;
-    n = 1;
-    break;
-  case PASORI_TYPE_S330:
-    recv[0] = 0xd4;
-    recv[1] = 0x02;
-    n = 2;
-    break;
-  default:
-    return PASORI_ERR_TYPE;
-  }
+    switch (p->type) {
+        case PASORI_TYPE_S310:
+        case PASORI_TYPE_S320:
+            recv[0] = 0x58;
+            n = 1;
+            break;
+        case PASORI_TYPE_S330:
+            recv[0] = 0xd4;
+            recv[1] = 0x02;
+            n = 2;
+            break;
+        default:
+            return PASORI_ERR_TYPE;
+    }
 
-  r = pasori_packet_write(p, recv, &n);
-  if (r)
-    return r;
+    r = pasori_packet_write(p, recv, &n);
+    if (r)
+        return r;
 
-  n = DATASIZE;
-  r = pasori_packet_read(p, recv, &n);
-  if (r)
-    return r;
+    n = DATASIZE;
+    r = pasori_packet_read(p, recv, &n);
+    if (r)
+        return r;
 
-  switch (p->type) {
-  case PASORI_TYPE_S310:
-  case PASORI_TYPE_S320:
-    if (recv[0] != 0x59)
-      return PASORI_ERR_FORMAT;
-    *v1 = recv[2];
-    *v2 = recv[1];
-    break;
-  case PASORI_TYPE_S330:
-    *v1 = bcd2int(recv[3]);
-    *v2 = bcd2int(recv[4]);
-    break;
-  default:
-    return PASORI_ERR_TYPE;
-  }
+    switch (p->type) {
+        case PASORI_TYPE_S310:
+        case PASORI_TYPE_S320:
+            if (recv[0] != 0x59)
+                return PASORI_ERR_FORMAT;
+            *v1 = recv[2];
+            *v2 = recv[1];
+            break;
+        case PASORI_TYPE_S330:
+            *v1 = bcd2int(recv[3]);
+            *v2 = bcd2int(recv[4]);
+            break;
+        default:
+            return PASORI_ERR_TYPE;
+    }
 
-  return 0;
+    return 0;
 }
 
-int 
-pasori_type(pasori *p)
-{
-  if (p == NULL) {
-    return -1;
-  }
+int pasori_type(pasori *p) {
+    if (p == NULL) {
+        return -1;
+    }
 
-  return p->type;
+    return p->type;
 }
 
 static void
-dbg_dump(unsigned char *b, uint8 size)
-{
-  int i;
+dbg_dump(unsigned char *b, uint8_t size) {
+    int i;
 
-  for (i = 0; i != size; i++) {
-    Log("%02X ", b[i]);
-  }
-  Log("\n");
+    for (i = 0; i != size; i++) {
+        Log("%02X ", b[i]);
+    }
+    Log("\n");
 }
 
-void
-pasori_close(pasori * pp)
-{
-  if (!pp)
-    return;
+void pasori_close(pasori *pp) {
+    if (!pp)
+        return;
 
 #ifdef HAVE_LIBUSB_1
-  if (pp->dh) {
-    pasori_reset(pp);
-    libusb_release_interface(pp->dh, INTERFACE_NUMBER);
-    libusb_close(pp->dh);
-  }
+    if (pp->dh) {
+        pasori_reset(pp);
+        libusb_release_interface(pp->dh, INTERFACE_NUMBER);
+        libusb_close(pp->dh);
+    }
 
-  if (pp->devs) {
-    libusb_free_device_list(pp->devs, 1);
-  }
+    if (pp->devs) {
+        libusb_free_device_list(pp->devs, 1);
+    }
 
-  if (pp->ctx) {
-    libusb_exit(pp->ctx);
-  }
-#else  /* HAVE_LIBUSB_1 */
-  if (pp->dh) {
-    pasori_reset(pp);
-    usb_release_interface(pp->dh,
-			  pp->dev->config->interface->altsetting->
-			  bInterfaceNumber);
-    usb_close(pp->dh);
-  }
+    if (pp->ctx) {
+        libusb_exit(pp->ctx);
+    }
+#else /* HAVE_LIBUSB_1 */
+    if (pp->dh) {
+        pasori_reset(pp);
+        usb_release_interface(pp->dh,
+                              pp->dev->config->interface->altsetting->bInterfaceNumber);
+        usb_close(pp->dh);
+    }
 #endif
 
-  free(pp);
+    free(pp);
 }
 
-static void 
-get_end_points(pasori *pas)
-{
+static void
+get_end_points(pasori *pas) {
 #ifdef HAVE_LIBUSB_1
-  struct libusb_config_descriptor *config;
-  const struct libusb_interface_descriptor *interdesc;
-  const struct libusb_endpoint_descriptor *epdesc;
-  const struct libusb_interface *inter;
-  libusb_device *dev;
-  int i, j, k;
+    struct libusb_config_descriptor *config;
+    const struct libusb_interface_descriptor *interdesc;
+    const struct libusb_endpoint_descriptor *epdesc;
+    const struct libusb_interface *inter;
+    libusb_device *dev;
+    int i, j, k;
 
-  dev = libusb_get_device(pas->dh);
-  libusb_get_config_descriptor(dev, 0, &config);
+    dev = libusb_get_device(pas->dh);
+    libusb_get_config_descriptor(dev, 0, &config);
 
-  for(i = 0; i < (int) config->bNumInterfaces; i++) {
-    inter = &config->interface[i];
-    for(j = 0; j < inter->num_altsetting; j++) {
-      interdesc = &inter->altsetting[j];
-      for(k = 0; k < (int) interdesc->bNumEndpoints; k++) {
-	epdesc = &interdesc->endpoint[k];
+    for (i = 0; i < (int)config->bNumInterfaces; i++) {
+        inter = &config->interface[i];
+        for (j = 0; j < inter->num_altsetting; j++) {
+            interdesc = &inter->altsetting[j];
+            for (k = 0; k < (int)interdesc->bNumEndpoints; k++) {
+                epdesc = &interdesc->endpoint[k];
 #ifdef DEBUG
-	printf("Endpoint      : 0x%02X\n"
-	       "Transfer Type : %x\n",
-	       epdesc->bEndpointAddress,
-	       epdesc->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK);
+                printf(
+                    "Endpoint      : 0x%02X\n"
+                    "Transfer Type : %x\n",
+                    epdesc->bEndpointAddress,
+                    epdesc->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK);
 #endif
-	switch (epdesc->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) {
-	case LIBUSB_TRANSFER_TYPE_BULK:
-	  if ((epdesc->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_IN) {
+                switch (epdesc->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) {
+                    case LIBUSB_TRANSFER_TYPE_BULK:
+                        if ((epdesc->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_IN) {
 #ifdef DEBUG
-	    printf("Bulk endpoint in  : 0x%02X\n", epdesc->bEndpointAddress);
+                            printf("Bulk endpoint in  : 0x%02X\n", epdesc->bEndpointAddress);
 #endif
-	    pas->b_ep_in = epdesc->bEndpointAddress;
-	  }
-	  if ((epdesc->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_OUT) {
+                            pas->b_ep_in = epdesc->bEndpointAddress;
+                        }
+                        if ((epdesc->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_OUT) {
 #ifdef DEBUG
-	    printf("Bulk endpoint out  : 0x%02X\n", epdesc->bEndpointAddress);
+                            printf("Bulk endpoint out  : 0x%02X\n", epdesc->bEndpointAddress);
 #endif
-	    pas->b_ep_out = epdesc->bEndpointAddress;
-	  }
-	  break;
-	case LIBUSB_TRANSFER_TYPE_INTERRUPT:
+                            pas->b_ep_out = epdesc->bEndpointAddress;
+                        }
+                        break;
+                    case LIBUSB_TRANSFER_TYPE_INTERRUPT:
 #ifdef DEBUG
-	  if ((epdesc->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_IN) {
-	    printf("Interrupt endpoint  : 0x%02X\n", epdesc->bEndpointAddress);
-	  }
+                        if ((epdesc->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_IN) {
+                            printf("Interrupt endpoint  : 0x%02X\n", epdesc->bEndpointAddress);
+                        }
 #endif
-	  pas->i_ep_in = epdesc->bEndpointAddress;
-	}
-      }
+                        pas->i_ep_in = epdesc->bEndpointAddress;
+                }
+            }
+        }
     }
-  }
-  libusb_free_config_descriptor(config);
-#else  /* HAVE_LIBUSB_1 */
-  int uiIndex;
-  int uiEndPoint;
-  struct usb_interface_descriptor* puid = pas->dev->config->interface->altsetting;
+    libusb_free_config_descriptor(config);
+#else /* HAVE_LIBUSB_1 */
+    int uiIndex;
+    int uiEndPoint;
+    struct usb_interface_descriptor *puid = pas->dev->config->interface->altsetting;
 
-  // 3 Endpoints maximum: Interrupt In, Bulk In, Bulk Out
-  for(uiIndex = 0; uiIndex < puid->bNumEndpoints; uiIndex++) {
-    // Copy the endpoint to a local var, makes it more readable code
-    uiEndPoint = puid->endpoint[uiIndex].bEndpointAddress;
+    // 3 Endpoints maximum: Interrupt In, Bulk In, Bulk Out
+    for (uiIndex = 0; uiIndex < puid->bNumEndpoints; uiIndex++) {
+        // Copy the endpoint to a local var, makes it more readable code
+        uiEndPoint = puid->endpoint[uiIndex].bEndpointAddress;
 
-    switch (puid->endpoint[uiIndex].bmAttributes) {
-    case USB_ENDPOINT_TYPE_BULK:
+        switch (puid->endpoint[uiIndex].bmAttributes) {
+            case USB_ENDPOINT_TYPE_BULK:
 
-      // Test if we dealing with a bulk IN endpoint
-      if((uiEndPoint & USB_ENDPOINT_DIR_MASK) == USB_ENDPOINT_IN) {
+                // Test if we dealing with a bulk IN endpoint
+                if ((uiEndPoint & USB_ENDPOINT_DIR_MASK) == USB_ENDPOINT_IN) {
 #ifdef DEBUG
-	printf("Bulk endpoint in  : 0x%02X\n", uiEndPoint);
+                    printf("Bulk endpoint in  : 0x%02X\n", uiEndPoint);
 #endif
-	pas->b_ep_in = uiEndPoint;
-      }
+                    pas->b_ep_in = uiEndPoint;
+                }
 
-      // Test if we dealing with a bulk OUT endpoint
-      if((uiEndPoint & USB_ENDPOINT_DIR_MASK) == USB_ENDPOINT_OUT) {
+                // Test if we dealing with a bulk OUT endpoint
+                if ((uiEndPoint & USB_ENDPOINT_DIR_MASK) == USB_ENDPOINT_OUT) {
 #ifdef DEBUG
-	printf("Bulk endpoint out  : 0x%02X\n", uiEndPoint);
+                    printf("Bulk endpoint out  : 0x%02X\n", uiEndPoint);
 #endif
-	pas->b_ep_out = uiEndPoint;
-      }
-      break;
-    case USB_ENDPOINT_TYPE_INTERRUPT:
-      if((uiEndPoint & USB_ENDPOINT_DIR_MASK) == USB_ENDPOINT_IN) {
+                    pas->b_ep_out = uiEndPoint;
+                }
+                break;
+            case USB_ENDPOINT_TYPE_INTERRUPT:
+                if ((uiEndPoint & USB_ENDPOINT_DIR_MASK) == USB_ENDPOINT_IN) {
 #ifdef DEBUG
-	printf("Interrupt endpoint  : 0x%02X\n", epdesc->bEndpointAddress);
+                    printf("Interrupt endpoint  : 0x%02X\n", epdesc->bEndpointAddress);
 #endif
-	pas->i_ep_in = uiEndPoint;
-      }
-      break;
+                    pas->i_ep_in = uiEndPoint;
+                }
+                break;
+        }
     }
-  }
-#endif	/* HAVE_LIBUSB_1 */
+#endif /* HAVE_LIBUSB_1 */
 }
 
 static int
-open_usb(pasori *pp)
-{
+open_usb(pasori *pp) {
 #ifdef HAVE_LIBUSB_1
-  int i, r, cnt;
-  struct libusb_device_descriptor desc;
-  libusb_device *dev;
+    int i, r, cnt;
+    struct libusb_device_descriptor desc;
+    libusb_device *dev;
 
-  pp->ctx = NULL;
-  pp->devs = NULL;
-  r = libusb_init(&pp->ctx);
-  if (r < 0) {
-    return PASORI_ERR_COM;
-  }
-#ifdef DEBUG_USB
-  libusb_set_debug(pp->ctx, 3);
-#endif
-  cnt = libusb_get_device_list(pp->ctx, &pp->devs); //get the list of devices
-  if(cnt < 0) {
-    return PASORI_ERR_COM;
-  }
-
-  for(i = 0; i < cnt; i++) {
-    r = libusb_get_device_descriptor(pp->devs[i], &desc);
+    pp->ctx = NULL;
+    pp->devs = NULL;
+    r = libusb_init(&pp->ctx);
     if (r < 0) {
-      continue;
+        return PASORI_ERR_COM;
+    }
+#ifdef DEBUG_USB
+    libusb_set_debug(pp->ctx, 3);
+#endif
+    cnt = libusb_get_device_list(pp->ctx, &pp->devs);  // get the list of devices
+    if (cnt < 0) {
+        return PASORI_ERR_COM;
     }
 
+    for (i = 0; i < cnt; i++) {
+        r = libusb_get_device_descriptor(pp->devs[i], &desc);
+        if (r < 0) {
+            continue;
+        }
+
 #ifdef DEBUG_USB
-    Log("Check for %04x:%04x\n", desc.idVendor, desc.idProduct);	/* debug */
+        Log("Check for %04x:%04x\n", desc.idVendor, desc.idProduct); /* debug */
 #endif
-    if (desc.idVendor == PASORIUSB_VENDOR && 
-	(desc.idProduct == PASORIUSB_PRODUCT_S310 ||
-	 desc.idProduct == PASORIUSB_PRODUCT_S320 ||
-	 desc.idProduct == PASORIUSB_PRODUCT_S330)) {
+        if (desc.idVendor == PASORIUSB_VENDOR &&
+            (desc.idProduct == PASORIUSB_PRODUCT_S310 ||
+             desc.idProduct == PASORIUSB_PRODUCT_S320 ||
+             desc.idProduct == PASORIUSB_PRODUCT_S330)) {
 #ifdef DEBUG_USB
-      Log("Device is found %04x:%04x\n", desc.idVendor, desc.idProduct);	/* debug */
+            Log("Device is found %04x:%04x\n", desc.idVendor, desc.idProduct); /* debug */
 #endif
-      dev = pp->devs[i];
-      goto finish;
+            dev = pp->devs[i];
+            goto finish;
+        }
     }
-  }
-  Log("pasori not found in USB BUS");
-  return PASORI_ERR_COM;
-
- finish:
-
-  switch (desc.idProduct) {
-  case PASORIUSB_PRODUCT_S310:
-    pp->type = PASORI_TYPE_S310;
-    break;
-  case PASORIUSB_PRODUCT_S320:
-    pp->type = PASORI_TYPE_S320;
-    break;
-  case PASORIUSB_PRODUCT_S330:
-    pp->type = PASORI_TYPE_S330;
-    break;
-  default:
-    return PASORI_ERR_TYPE;
-  }
-
-  r = libusb_open(dev, &pp->dh);
-  if(r) {
+    Log("pasori not found in USB BUS");
     return PASORI_ERR_COM;
-  }
 
-  if(libusb_kernel_driver_active(pp->dh, 0) == 1) {
-    r = libusb_detach_kernel_driver(pp->dh, 0);
+finish:
+
+    switch (desc.idProduct) {
+        case PASORIUSB_PRODUCT_S310:
+            pp->type = PASORI_TYPE_S310;
+            break;
+        case PASORIUSB_PRODUCT_S320:
+            pp->type = PASORI_TYPE_S320;
+            break;
+        case PASORIUSB_PRODUCT_S330:
+            pp->type = PASORI_TYPE_S330;
+            break;
+        default:
+            return PASORI_ERR_TYPE;
+    }
+
+    r = libusb_open(dev, &pp->dh);
     if (r) {
-      return PASORI_ERR_COM;
+        return PASORI_ERR_COM;
     }
-  }
 
-  pp->timeout = TIMEOUT;
-  get_end_points(pp);
+    if (libusb_kernel_driver_active(pp->dh, 0) == 1) {
+        r = libusb_detach_kernel_driver(pp->dh, 0);
+        if (r) {
+            return PASORI_ERR_COM;
+        }
+    }
 
-  if(libusb_claim_interface(pp->dh, INTERFACE_NUMBER) < 0) {
-    return PASORI_ERR_COM;
-  }
+    pp->timeout = TIMEOUT;
+    get_end_points(pp);
 
-  return 0;
-#else  /* HAVE_LIBUSB_1 */
-  struct usb_bus *bus;
-  struct usb_device *dev;
+    if (libusb_claim_interface(pp->dh, INTERFACE_NUMBER) < 0) {
+        return PASORI_ERR_COM;
+    }
 
-  usb_init();
+    return 0;
+#else /* HAVE_LIBUSB_1 */
+    struct usb_bus *bus;
+    struct usb_device *dev;
+
+    usb_init();
 #ifdef DEBUG_USB
-  usb_set_debug(255);
+    usb_set_debug(255);
 #else
-  usb_set_debug(0);
+    usb_set_debug(0);
 #endif
-  usb_find_busses();
-  usb_find_devices();
+    usb_find_busses();
+    usb_find_devices();
 
-  for (bus = usb_get_busses(); bus; bus = bus->next) {
-    for (dev = bus->devices; dev; dev = dev->next) {
+    for (bus = usb_get_busses(); bus; bus = bus->next) {
+        for (dev = bus->devices; dev; dev = dev->next) {
 #ifdef DEBUG_USB
-      Log("check for %04x:%04x\n", dev->descriptor.idVendor, dev->descriptor.idProduct);	/* debug */
+            Log("check for %04x:%04x\n", dev->descriptor.idVendor, dev->descriptor.idProduct); /* debug */
 #endif
-      if (dev->descriptor.idVendor == PASORIUSB_VENDOR &&
-	  (dev->descriptor.idProduct == PASORIUSB_PRODUCT_S310 ||
-	   dev->descriptor.idProduct == PASORIUSB_PRODUCT_S320 ||
-	   dev->descriptor.idProduct == PASORIUSB_PRODUCT_S330)) {
+            if (dev->descriptor.idVendor == PASORIUSB_VENDOR &&
+                (dev->descriptor.idProduct == PASORIUSB_PRODUCT_S310 ||
+                 dev->descriptor.idProduct == PASORIUSB_PRODUCT_S320 ||
+                 dev->descriptor.idProduct == PASORIUSB_PRODUCT_S330)) {
 #ifdef DEBUG_USB
-	Log("Device is found %04x:%04x\n", dev->descriptor.idVendor, dev->descriptor.idProduct);	/* debug */
+                Log("Device is found %04x:%04x\n", dev->descriptor.idVendor, dev->descriptor.idProduct); /* debug */
 #endif
-	goto finish;
-      }
+                goto finish;
+            }
+        }
     }
-  }
-  Log("pasori not found in USB BUS");
-  return PASORI_ERR_COM;
-
- finish:
-  switch (dev->descriptor.idProduct) {
-  case PASORIUSB_PRODUCT_S310:
-    pp->type = PASORI_TYPE_S310;
-    break;
-  case PASORIUSB_PRODUCT_S320:
-    pp->type = PASORI_TYPE_S320;
-    break;
-  case PASORIUSB_PRODUCT_S330:
-    pp->type = PASORI_TYPE_S330;
-    break;
-  default:
-    return PASORI_ERR_TYPE;
-  }
-
-  pp->dh = usb_open(dev);
-  pp->dev = dev;
-  pp->timeout = TIMEOUT;
-  get_end_points(pp);
-
-  if (usb_set_configuration(pp->dh, 1)) {
-    /* error */
+    Log("pasori not found in USB BUS");
     return PASORI_ERR_COM;
-  }
 
-  if (usb_claim_interface
-      (pp->dh, pp->dev->config->interface->altsetting->bInterfaceNumber)) {
-    /* error */
-    return PASORI_ERR_COM;
-  }
-  return 0;
-#endif	/* HAVE_LIBUSB_1 */
+finish:
+    switch (dev->descriptor.idProduct) {
+        case PASORIUSB_PRODUCT_S310:
+            pp->type = PASORI_TYPE_S310;
+            break;
+        case PASORIUSB_PRODUCT_S320:
+            pp->type = PASORI_TYPE_S320;
+            break;
+        case PASORIUSB_PRODUCT_S330:
+            pp->type = PASORI_TYPE_S330;
+            break;
+        default:
+            return PASORI_ERR_TYPE;
+    }
+
+    pp->dh = usb_open(dev);
+    pp->dev = dev;
+    pp->timeout = TIMEOUT;
+    get_end_points(pp);
+
+    if (usb_set_configuration(pp->dh, 1)) {
+        /* error */
+        return PASORI_ERR_COM;
+    }
+
+    if (usb_claim_interface(pp->dh, pp->dev->config->interface->altsetting->bInterfaceNumber)) {
+        /* error */
+        return PASORI_ERR_COM;
+    }
+    return 0;
+#endif /* HAVE_LIBUSB_1 */
 }
 
 pasori *
-pasori_open(void)
-{
-  pasori *pp;
+pasori_open(void) {
+    pasori *pp;
 
-  pp = (pasori *) malloc(sizeof(pasori));
+    pp = (pasori *)malloc(sizeof(pasori));
 
-  if (pp == NULL)
-    return NULL;
+    if (pp == NULL)
+        return NULL;
 
-  memset(pp, 0, sizeof(pasori));
-  pp->i_ep_in = 0x81;
+    memset(pp, 0, sizeof(pasori));
+    pp->i_ep_in = 0x81;
 
-  if (open_usb(pp)) {
-    pasori_close(pp);
-    return NULL;
-  }
+    if (open_usb(pp)) {
+        pasori_close(pp);
+        return NULL;
+    }
 
-  return pp;
+    return pp;
 }
 
-int
-pasori_send(pasori *pp, uint8 *data, int *size)
-{
-  uint8 resp[256];
-  signed int i = - 1;
-#ifdef HAVE_LIBUSB_1		/* HAVE_LIBUSB_1 */
-  int length;
+int pasori_send(pasori *pp, uint8_t *data, int *size) {
+    uint8_t resp[256];
+    signed int i = -1;
+#ifdef HAVE_LIBUSB_1 /* HAVE_LIBUSB_1 */
+    int length;
 #endif
-  if (pp == NULL || data == NULL || size == NULL)
-    return PASORI_ERR_PARM;
+    if (pp == NULL || data == NULL || size == NULL)
+        return PASORI_ERR_PARM;
 
-  if (*size < 1)
+    if (*size < 1)
+        return 0;
+
+    Log("(send) send:");
+    dbg_dump(data, *size);
+
+    switch (pp->type) {
+        case PASORI_TYPE_S310:
+        case PASORI_TYPE_S320:
+#ifdef HAVE_LIBUSB_1 /* HAVE_LIBUSB_1 */
+            i = libusb_control_transfer(pp->dh, LIBUSB_REQUEST_TYPE_VENDOR, 0, 0, 0, data, *size, pp->timeout);
+#else  /* HAVE_LIBUSB_1 */
+            i = usb_control_msg(pp->dh, USB_TYPE_VENDOR, 0, 0, 0, data, *size, pp->timeout);
+#endif /* HAVE_LIBUSB_1 */
+            break;
+        case PASORI_TYPE_S330:
+#ifdef HAVE_LIBUSB_1 /* HAVE_LIBUSB_1 */
+            i = libusb_bulk_transfer(pp->dh, pp->b_ep_out, data, *size, &length, pp->timeout);
+#else  /* HAVE_LIBUSB_1 */
+            i = usb_bulk_write(pp->dh, pp->b_ep_out, data, *size, pp->timeout);
+#endif /* HAVE_LIBUSB_1 */
+            break;
+        default:
+            return PASORI_ERR_TYPE;
+    }
+
+    if (i < 0)
+        return PASORI_ERR_COM; /* FIXME:HANDLE INVALID RESPONSES */
+
+#ifdef HAVE_LIBUSB_1 /* HAVE_LIBUSB_1 */
+    *size = length;
+#else
+    *size = i;
+#endif
+
+    switch (pp->type) {
+        case PASORI_TYPE_S310:
+        case PASORI_TYPE_S320:
+#ifdef HAVE_LIBUSB_1 /* HAVE_LIBUSB_1 */
+            i = libusb_interrupt_transfer(pp->dh, pp->i_ep_in, resp, sizeof(resp), &length, pp->timeout);
+#else  /* HAVE_LIBUSB_1 */
+            i = usb_interrupt_read(pp->dh, pp->i_ep_in, resp, sizeof(resp), pp->timeout);
+#endif /* HAVE_LIBUSB_1 */
+            break;
+        case PASORI_TYPE_S330:
+#ifdef HAVE_LIBUSB_1 /* HAVE_LIBUSB_1 */
+            i = libusb_bulk_transfer(pp->dh, pp->b_ep_in, resp, sizeof(resp), &length, pp->timeout);
+#else  /* HAVE_LIBUSB_1 */
+            i = usb_bulk_read(pp->dh, pp->b_ep_in, resp, sizeof(resp), pp->timeout);
+#endif /* HAVE_LIBUSB_1 */
+            break;
+        default:
+            return PASORI_ERR_TYPE;
+    }
+
+#ifdef HAVE_LIBUSB_1 /* HAVE_LIBUSB_1 */
+    if (i)
+        return PASORI_ERR_COM; /* FIXME:HANDLE INVALID RESPONSES */
+
+    if (length != 6)
+        return PASORI_ERR_DATA;
+
+    i = length;
+#else
+    if (i < 0)
+        return PASORI_ERR_COM; /* FIXME:HANDLE INVALID RESPONSES */
+
+    if (i != 6)
+        return PASORI_ERR_DATA;
+#endif
+
+    if (resp[4] != 0xff)
+        return PASORI_ERR_DATA;
+
+    /* debug */
+    Log("(ACK?) recv:");
+    dbg_dump(resp, i);
+
     return 0;
-
-  Log("(send) send:");
-  dbg_dump(data, *size);
-
-  switch (pp->type) {
-  case PASORI_TYPE_S310:
-  case PASORI_TYPE_S320:
-#ifdef HAVE_LIBUSB_1		/* HAVE_LIBUSB_1 */
-    i = libusb_control_transfer(pp->dh, LIBUSB_REQUEST_TYPE_VENDOR, 0, 0, 0, data, *size, pp->timeout);
-#else  /* HAVE_LIBUSB_1 */
-    i = usb_control_msg(pp->dh, USB_TYPE_VENDOR, 0, 0, 0, data, *size, pp->timeout);
-#endif	/* HAVE_LIBUSB_1 */
-    break;
-  case PASORI_TYPE_S330:
-#ifdef HAVE_LIBUSB_1		/* HAVE_LIBUSB_1 */
-    i = libusb_bulk_transfer(pp->dh, pp->b_ep_out, data, *size, &length, pp->timeout);
-#else  /* HAVE_LIBUSB_1 */
-    i = usb_bulk_write(pp->dh, pp->b_ep_out, data, *size, pp->timeout);
-#endif	/* HAVE_LIBUSB_1 */
-    break;
-  default:
-    return PASORI_ERR_TYPE;
-  }
-
-  if (i < 0)
-    return PASORI_ERR_COM;			/* FIXME:HANDLE INVALID RESPONSES */
-
-#ifdef HAVE_LIBUSB_1		/* HAVE_LIBUSB_1 */
-  *size = length;
-#else
-  *size = i;
-#endif
-
-  switch (pp->type) {
-  case PASORI_TYPE_S310:
-  case PASORI_TYPE_S320:
-#ifdef HAVE_LIBUSB_1		/* HAVE_LIBUSB_1 */
-    i = libusb_interrupt_transfer(pp->dh, pp->i_ep_in, resp, sizeof(resp), &length, pp->timeout);
-#else  /* HAVE_LIBUSB_1 */
-    i = usb_interrupt_read(pp->dh, pp->i_ep_in, resp, sizeof(resp), pp->timeout);
-#endif	/* HAVE_LIBUSB_1 */
-    break;
-  case PASORI_TYPE_S330:
-#ifdef HAVE_LIBUSB_1		/* HAVE_LIBUSB_1 */
-    i = libusb_bulk_transfer(pp->dh, pp->b_ep_in, resp, sizeof(resp), &length, pp->timeout);
-#else  /* HAVE_LIBUSB_1 */
-    i = usb_bulk_read(pp->dh, pp->b_ep_in, resp, sizeof(resp), pp->timeout);
-#endif	/* HAVE_LIBUSB_1 */
-    break;
-  default:
-    return PASORI_ERR_TYPE;
-  }
-
-#ifdef HAVE_LIBUSB_1		/* HAVE_LIBUSB_1 */
-  if (i)
-    return PASORI_ERR_COM;			/* FIXME:HANDLE INVALID RESPONSES */
-
-  if (length != 6)
-    return PASORI_ERR_DATA;
-
-  i = length;
-#else
-  if (i < 0)
-    return PASORI_ERR_COM;			/* FIXME:HANDLE INVALID RESPONSES */
-
-  if (i != 6)
-    return PASORI_ERR_DATA;
-#endif
-
-  if (resp[4] != 0xff)
-    return PASORI_ERR_DATA;
-
-  /* debug */
-  Log("(ACK?) recv:");
-  dbg_dump(resp, i);
-
-  return 0;
-
 }
 
-int
-pasori_recv(pasori *pp, uint8 *data, int *size)
-{
-  signed int i;
-#ifdef HAVE_LIBUSB_1		/* HAVE_LIBUSB_1 */
-  int length;
-#endif	/* HAVE_LIBUSB_1 */
+int pasori_recv(pasori *pp, uint8_t *data, int *size) {
+    signed int i;
+#ifdef HAVE_LIBUSB_1 /* HAVE_LIBUSB_1 */
+    int length;
+#endif /* HAVE_LIBUSB_1 */
 
-  if (pp == NULL || data == NULL || size == NULL)
-    return 1;
+    if (pp == NULL || data == NULL || size == NULL)
+        return 1;
 
-  if (*size < 1)
-    return 0;
+    if (*size < 1)
+        return 0;
 
-  switch (pp->type) {
-  case PASORI_TYPE_S310:
-  case PASORI_TYPE_S320:
-#ifdef HAVE_LIBUSB_1		/* HAVE_LIBUSB_1 */
-    length = *size;
-    i = libusb_interrupt_transfer(pp->dh, pp->i_ep_in, data, length, size, pp->timeout);
+    switch (pp->type) {
+        case PASORI_TYPE_S310:
+        case PASORI_TYPE_S320:
+#ifdef HAVE_LIBUSB_1 /* HAVE_LIBUSB_1 */
+            length = *size;
+            i = libusb_interrupt_transfer(pp->dh, pp->i_ep_in, data, length, size, pp->timeout);
 #else  /* HAVE_LIBUSB_1 */
-    i = usb_interrupt_read(pp->dh, pp->i_ep_in, data, *size, pp->timeout);
-#endif	/* HAVE_LIBUSB_1 */
-    break;
-  case PASORI_TYPE_S330:
-#ifdef HAVE_LIBUSB_1		/* HAVE_LIBUSB_1 */
-    length = *size;
-    i = libusb_bulk_transfer(pp->dh, pp->b_ep_in, data, length, size, pp->timeout);
-#else  /* HAVE_LIBUSB_1 */
-    i = usb_bulk_read(pp->dh, pp->b_ep_in, data, *size, pp->timeout);
+            i = usb_interrupt_read(pp->dh, pp->i_ep_in, data, *size, pp->timeout);
+#endif /* HAVE_LIBUSB_1 */
+            break;
+        case PASORI_TYPE_S330:
+#ifdef HAVE_LIBUSB_1 /* HAVE_LIBUSB_1 */
+            length = *size;
+            i = libusb_bulk_transfer(pp->dh, pp->b_ep_in, data, length, size, pp->timeout);
+#else /* HAVE_LIBUSB_1 */
+            i = usb_bulk_read(pp->dh, pp->b_ep_in, data, *size, pp->timeout);
 #endif
-    break;
-  default:
-    return PASORI_ERR_TYPE;
-  }
+            break;
+        default:
+            return PASORI_ERR_TYPE;
+    }
 
-#ifdef HAVE_LIBUSB_1		/* HAVE_LIBUSB_1 */
-  if (i) {
-    Log("(recv) ERROR %d\n", i);
-    return PASORI_ERR_COM;
-  }
-  i = length;
+#ifdef HAVE_LIBUSB_1 /* HAVE_LIBUSB_1 */
+    if (i) {
+        Log("(recv) ERROR %d\n", i);
+        return PASORI_ERR_COM;
+    }
+    i = length;
 #else
-  if (i < 0) {
-    Log("(recv) ERROR\n");
-    return PASORI_ERR_COM;
-  }
+    if (i < 0) {
+        Log("(recv) ERROR\n");
+        return PASORI_ERR_COM;
+    }
 #endif
 
-  Log("(recv) recv:");
-  dbg_dump(data, i);
-  *size = i;
+    Log("(recv) recv:");
+    dbg_dump(data, i);
+    *size = i;
 
-  return 0;
+    return 0;
 }

--- a/tests/felica_dump.c
+++ b/tests/felica_dump.c
@@ -6,14 +6,14 @@
 
 #include "libpafe.h"
 
-void mydump(uint8 *p, int size) {
+void mydump(uint8_t *p, int size) {
     int i;
     for (i = 0; i != size; i++) {
         printf("%02X", p[i]);
     }
 }
 
-void show_idminfo(uint8 *idm) {
+void show_idminfo(uint8_t *idm) {
     time_t mtime;
     time_t ntime;
     struct tm fepoc;
@@ -65,7 +65,7 @@ const sinfo Sifo[] = {
     {11, " Purse (Read Only)         "},
     {-1, " INVALID or UNKNOWN        "}};
 
-void print_service_info(uint16 attr) {
+void print_service_info(uint16_t attr) {
     unsigned int j;
 
     for (j = 0; j < sizeof(Sifo) / sizeof(*Sifo); j++) {
@@ -82,7 +82,7 @@ void print_service_info(uint16 attr) {
 }
 
 void dump_service(felica *f) {
-    uint8 b[16];
+    uint8_t b[16];
     int i, j, r;
 
     r = felica_search_service(f);
@@ -125,7 +125,7 @@ void dump_service(felica *f) {
 
 void enum_service(felica *f) {
     felica *ff;
-    uint16 resp[256];
+    uint16_t resp[256];
     int i, n, r;
 
     n = sizeof(resp) / sizeof(*resp);


### PR DESCRIPTION
- `stdint.h` をincludeし、`uint8` の代わりに `uint8_t` を、`uint16`の代わりに `uint16_t` を使うよう変更
- インクルードガードの定数を変更