### PR TITLE
[Update] search libusb 0.1 and 1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 add_subdirectory(src)
 
 option(LIBPAFE_BUILD_SAMPLES "Build sample programs" OFF)
+option(LIBPAFE_FORCE_LIBUSB1 "Force to use libusb 1.0" ON)
 
 if(LIBPAFE_BUILD_SAMPLES)
     message(NOTICE "Build samples")

--- a/cmake/configure-libusb.cmake
+++ b/cmake/configure-libusb.cmake
@@ -1,0 +1,36 @@
+#
+# Configure libusb
+#
+cmake_minimum_required(VERSION 3.21)
+
+include(FindPackageHandleStandardArgs)
+
+# Find libusb 0.1
+find_path(LIBUSB_0_INCLUDE_DIR NAMES usb.h PATH_SUFFIXES "libusb-0.1")
+find_library(LIBUSB_0_LIBRARY NAMES usb)
+find_package_handle_standard_args(libusb_0 DEFAULT_MSG LIBUSB_0_LIBRARY LIBUSB_0_INCLUDE_DIR)
+
+if(LIBUSB_0_FOUND)
+    set(LIBUSB_INCLUDE_DIR ${LIBUSB_0_INCLUDE_DIR})
+    set(LIBUSB_LIBRARY ${LIBUSB_0_LIBRARY})
+    set(LIBUSB_CAPABILITY "HAVE_LIBUSB")
+endif()
+
+# Find libusb 1.0
+find_path(LIBUSB_1_INCLUDE_DIR NAMES libusb.h PATH_SUFFIXES "libusb-1.0")
+find_library(LIBUSB_1_LIBRARY NAMES usb-1.0)
+find_package_handle_standard_args(libusb_1 DEFAULT_MSG LIBUSB_1_LIBRARY LIBUSB_1_INCLUDE_DIR)
+
+if(LIBUSB_1_FOUND)
+    set(LIBUSB_INCLUDE_DIR ${LIBUSB_1_INCLUDE_DIR})
+    set(LIBUSB_LIBRARY ${LIBUSB_1_LIBRARY})
+    set(LIBUSB_CAPABILITY "HAVE_LIBUSB_1")
+endif()
+
+if(LIBPAFE_FORCE_LIBUSB1)
+    message(NOTICE "The use of libusb-1.0 has been forced.")
+
+    if(NOT LIBUSB_1_FOUND)
+        message(FATAL_ERROR "The use of libusb-1.0 was forced, but it was not found. Please confirm whether it's installed.")
+    endif()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,18 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
-# Find libusb 1.0
-find_path(LIBUSB_INCLUDE_DIR
-    NAMES libusb.h
-    PATH_SUFFIXES "libusb-1.0"
-)
-
-find_library(LIBUSB_LIBRARY
-    NAMES usb-1.0
-    REQUIRED
-)
-message(NOTICE "libusb found")
-message(NOTICE ${LIBUSB_INCLUDE_DIR})
-message(NOTICE ${LIBUSB_LIBRARY})
+# Find libusb variants
+include(${PROJECT_SOURCE_DIR}/cmake/configure-libusb.cmake)
 
 # Configure library
 add_library(pafe)
@@ -25,7 +14,7 @@ target_include_directories(pafe PUBLIC
     ${LIBUSB_INCLUDE_DIR}
 )
 target_compile_definitions(pafe PRIVATE
-    HAVE_LIBUSB_1
+    ${LIBUSB_CAPABILITY}
 )
 target_compile_options(pafe PRIVATE
     -Wall


### PR DESCRIPTION
- CMake構成時にlibusbの0.1と1.0の双方を検索するよう構成
- libusb 1.0系の使用を強制するオプション LIBPAFE_FORCE_LIBUSB1 を追加